### PR TITLE
Method to get `http::Request` from RequestBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-hyper-client"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -165,8 +165,12 @@ impl RequestDetails {
             body: None,
         }
     }
+    pub async fn send(self, client: &Client) -> Result<Response, Error> {
+        let req = self.into_request()?;
+        Ok(client.inner.request(req).await?)
+    }
 
-    pub async fn send(mut self, client: &Client) -> Result<Response, Error> {
+    pub fn into_request(mut self) -> Result<Request<SharedBody>, Error> {
         let can_have_body = match self.method {
             // See RFC 7231 section 4.3
             Method::GET | Method::HEAD | Method::DELETE => false,
@@ -198,8 +202,8 @@ impl RequestDetails {
                 }
             },
         }
-        let req = req.body(body)?;
-        Ok(client.inner.request(req).await?)
+
+        Ok(req.body(body)?)
     }
 }
 
@@ -207,6 +211,8 @@ impl RequestDetails {
 ///
 /// This is created through [`Client::get()`], [`Client::post()`] etc.
 /// You need to call [`send()`] to actually send the request over the network.
+/// If you don't want to send it and just want the resultant [Request], you
+/// can call [RequestBuilder::build].
 ///
 /// [`Client::get()`]: struct.Client.html#method.get
 /// [`Client::post()`]: struct.Client.html#method.post
@@ -235,6 +241,14 @@ impl<'a> RequestBuilder<'a> {
     pub fn header<H: Header>(mut self, header: H) -> Self {
         self.details.headers.typed_insert(header);
         self
+    }
+
+    /// Get the resultant [Request].
+    ///
+    /// Prefer [RequestBuilder::send] unless you have a specific
+    /// need to get the resultant [Request].
+    pub fn build(self) -> Result<Request<SharedBody>, Error> {
+        self.details.into_request()
     }
 
     /// Send the request over the network.

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -64,6 +64,12 @@ impl Client {
         ClientBuilder::new().build(connector)
     }
 
+    /// This method can be used instead of [Client::request]
+    /// if the caller already has a [Request].
+    pub async fn send(&self, request: Request<SharedBody>) -> Result<Response, Error> {
+        Ok(self.inner.request(request).await?)
+    }
+
     /// Initiate a request with the specified method and URI.
     ///
     /// Returns an error if `uri` is invalid.

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -171,6 +171,7 @@ impl RequestDetails {
             body: None,
         }
     }
+
     pub async fn send(self, client: &Client) -> Result<Response, Error> {
         let req = self.into_request()?;
         Ok(client.inner.request(req).await?)


### PR DESCRIPTION
It is sometimes useful to get the intermediate `http::Request` instead of sending directly. An example can be `aws-sigv4` crate which accepts `http::Request` for signing. This PR adds method to get that.