### PR TITLE
Make client builder cloneable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-hyper-client"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -98,6 +98,7 @@ impl Client {
 /// A builder for [`Client`]
 ///
 /// [`Client`]: struct.Client.html
+#[derive(Clone)]
 pub struct ClientBuilder {
     max_idle_per_host: usize,
     idle_timeout: Option<Duration>,

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -108,6 +108,7 @@ impl Client {
 /// A builder for [`Client`].
 ///
 /// [`Client`]: struct.Client.html
+#[derive(Clone)]
 pub struct ClientBuilder(AsyncClientBuilder);
 
 impl ClientBuilder {


### PR DESCRIPTION
I have a project where I store a `ClientBuilder` in an `Arc` and I want to call `Arc::make_mut()` on it, which requires the `ClientBuilder` to be cloneable. This PR adds a `#[derive(Clone)]` attribute to both the sync and async versions of the `Clientbuilder`.