### PR TITLE
feat: upgrade `hyper` to v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -442,15 +448,15 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -467,9 +473,9 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "headers"
-version = "0.3.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
  "base64",
  "bytes",
@@ -482,33 +488,45 @@ dependencies = [
 
 [[package]]
 name = "headers-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -525,25 +543,43 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
- "want",
 ]
 
 [[package]]
@@ -968,20 +1004,23 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simple-hyper-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "futures-executor",
  "futures-util",
  "headers",
  "http",
+ "http-body-util",
  "hyper",
+ "hyper-util",
+ "thiserror",
  "tokio",
- "tokio-stream",
+ "tower-service",
 ]
 
 [[package]]
 name = "simple-hyper-client-native-tls"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "simple-hyper-client",
  "tokio",
@@ -990,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "simple-hyper-client-rustls"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "env_logger",
  "rustls-pki-types",
@@ -1007,6 +1046,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -1047,6 +1092,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1092,17 +1157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -1212,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2024"
 publish = false
 
 [dependencies]
-simple-hyper-client = { version = "0.2.0", path = "../simple-hyper-client" }
-simple-hyper-client-native-tls = { version = "0.1.0", path = "../simple-hyper-client-native-tls" }
-simple-hyper-client-rustls = { version = "0.1.0", path = "../simple-hyper-client-rustls" }
-tokio = { version = "1.50.0"}
-tokio-native-tls = { version = "0.3.0" }
-tokio-rustls = { version = "0.26.4" }
-webpki-roots = { version = "1.0.6" }
+simple-hyper-client = { version = "0.3", path = "../simple-hyper-client" }
+simple-hyper-client-native-tls = { version = "0.2", path = "../simple-hyper-client-native-tls" }
+simple-hyper-client-rustls = { version = "0.2", path = "../simple-hyper-client-rustls" }
+tokio = { version = "1.50"}
+tokio-native-tls = { version = "0.3" }
+tokio-rustls = { version = "0.26" }
+webpki-roots = { version = "1.0" }
 
 
 [[bin]]

--- a/simple-hyper-client-native-tls/Cargo.toml
+++ b/simple-hyper-client-native-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-hyper-client-native-tls"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -14,6 +14,6 @@ categories = ["web-programming::http-client"]
 edition = "2018"
 
 [dependencies]
-simple-hyper-client = { version = "0.2.0", path = "../simple-hyper-client" }
-tokio = { version = "1.50.0", features = ["rt", "macros", "net", "sync", "time"] }
-tokio-native-tls = { version = "0.3.0" }
+simple-hyper-client = { version = "0.3", path = "../simple-hyper-client" }
+tokio = { version = "1", features = ["rt", "macros", "net", "sync", "time"] }
+tokio-native-tls = { version = "0.3" }

--- a/simple-hyper-client-native-tls/src/lib.rs
+++ b/simple-hyper-client-native-tls/src/lib.rs
@@ -6,8 +6,8 @@
 
 use simple_hyper_client::{ConnectError, HttpConnection, NetworkConnection, NetworkConnector};
 
+use simple_hyper_client::compat::{Connected, Connection};
 use simple_hyper_client::connector_impl;
-use simple_hyper_client::hyper::client::connect::{Connected, Connection};
 use simple_hyper_client::Uri;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;

--- a/simple-hyper-client-rustls/Cargo.toml
+++ b/simple-hyper-client-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-hyper-client-rustls"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -14,10 +14,10 @@ categories = ["web-programming::http-client"]
 edition = "2018"
 
 [dependencies]
-rustls-pki-types = { version = "1.14.0" }
-simple-hyper-client = { version = "0.2.0", path = "../simple-hyper-client" }
-tokio = { version = "1.50.0", features = ["rt", "macros", "net", "sync", "time"] }
-tokio-rustls = { version = "0.26.4" }
+rustls-pki-types = { version = "1.14" }
+simple-hyper-client = { version = "0.3", path = "../simple-hyper-client" }
+tokio = { version = "1", features = ["rt", "macros", "net", "sync", "time"] }
+tokio-rustls = { version = "0.26" }
 
 [dev-dependencies]
-env_logger = "0.11.9"
+env_logger = "0.11"

--- a/simple-hyper-client-rustls/src/lib.rs
+++ b/simple-hyper-client-rustls/src/lib.rs
@@ -6,8 +6,8 @@
 
 use simple_hyper_client::{ConnectError, HttpConnection, NetworkConnection, NetworkConnector};
 
+use simple_hyper_client::compat::{Connected, Connection};
 use simple_hyper_client::connector_impl;
-use simple_hyper_client::hyper::client::connect::{Connected, Connection};
 use simple_hyper_client::Uri;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;

--- a/simple-hyper-client/Cargo.toml
+++ b/simple-hyper-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-hyper-client"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -14,12 +14,17 @@ categories = ["web-programming::http-client"]
 edition = "2018"
 
 [dependencies]
-futures-executor = "0.3.32"
-headers = "0.3.7"
-http = "0.2.6"
-hyper = { version = "0.14.17", features = ["client", "http1", "http2", "stream"] }
-tokio = { version = "1.50.0", features = ["rt", "macros", "net", "sync", "time"] }
-tokio-stream = "0.1.18"
+futures-executor = "0.3"
+futures-util = "0.3"
+headers = "0.4"
+http = "1.4"
+http-body-util = "0.1"
+hyper = { version = "1.10", features = ["client", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "service"] }
+thiserror = "2.0"
+tokio = { version = "1", features = ["rt", "macros", "net", "sync", "time"] }
+tower-service = "0.3"
 
 [dev-dependencies]
-futures-util = "0.3.32"
+http-body-util = { version = "0.1", features = ["channel"] }
+futures-util = "0.3"

--- a/simple-hyper-client/src/async_client.rs
+++ b/simple-hyper-client/src/async_client.rs
@@ -103,13 +103,17 @@ pub struct ClientBuilder(HyperClientBuilder);
 
 impl Default for ClientBuilder {
     fn default() -> Self {
-        Self::new(HyperClientBuilder::new(TokioExecutor))
+        Self::new()
     }
 }
 
 impl ClientBuilder {
+    pub fn new() -> Self {
+        Self::from_hyper_client_builder(HyperClientBuilder::new(TokioExecutor))
+    }
+
     /// Create a builder with a configured instance of [`HyperClientBuilder`].
-    pub fn new(inner: HyperClientBuilder) -> Self {
+    pub fn from_hyper_client_builder(inner: HyperClientBuilder) -> Self {
         Self(inner)
     }
 
@@ -132,11 +136,6 @@ impl ClientBuilder {
     }
 
     /// Set whether the connection **must** use HTTP/2.
-    ///
-    /// The destination must either allow HTTP2 Prior Knowledge, or the
-    /// `Connect` should be configured to do use ALPN to upgrade to `h2`
-    /// as part of the connection process. This will not make the `Client`
-    /// utilize ALPN by itself.
     ///
     /// Note that setting this to true prevents HTTP/1 from being allowed.
     ///

--- a/simple-hyper-client/src/async_client.rs
+++ b/simple-hyper-client/src/async_client.rs
@@ -7,10 +7,10 @@
 use crate::connector::{ConnectorAdapter, NetworkConnector};
 use crate::error::Error;
 use crate::shared_body::SharedBody;
-use crate::Response;
+use crate::{HyperClient, HyperClientBuilder, Response};
 
 use headers::{ContentLength, Header, HeaderMap, HeaderMapExt};
-use hyper::{Client as HyperClient, Method, Request, Uri};
+use hyper::{Method, Request, Uri};
 
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -27,7 +27,7 @@ use std::time::Duration;
 /// let response = client.get("http://example.com/")?.send().await?;
 /// ```
 ///
-/// [hyper's `Client` type]: https://docs.rs/hyper/latest/hyper/client/struct.Client.html
+/// [hyper's `Client` type]: https://docs.rs/hyper-util/latest/hyper_util/client/legacy/struct.Client.html
 #[derive(Clone)]
 pub struct Client {
     inner: Arc<HyperClient<ConnectorAdapter, SharedBody>>,
@@ -56,12 +56,12 @@ macro_rules! define_method_fn {
 
 impl Client {
     pub fn builder() -> ClientBuilder {
-        ClientBuilder::new()
+        ClientBuilder::default()
     }
 
     /// Create a new `Client` using the specified connector.
     pub fn with_connector<C: NetworkConnector>(connector: C) -> Self {
-        ClientBuilder::new().build(connector)
+        ClientBuilder::default().build(connector)
     }
 
     /// This method can be used instead of [Client::request]
@@ -93,30 +93,31 @@ impl Client {
     define_method_fn!(delete, DELETE);
 }
 
-// NOTE: the default values are taken from https://docs.rs/hyper/0.13.10/hyper/client/struct.Builder.html
+// NOTE: the default values are taken from https://docs.rs/hyper-util/latest/hyper_util/client/legacy/struct.Builder.html
 // NOTE: not all configurable aspects of hyper Client are exposed here.
 /// A builder for [`Client`]
 ///
 /// [`Client`]: struct.Client.html
 #[derive(Clone)]
-pub struct ClientBuilder {
-    max_idle_per_host: usize,
-    idle_timeout: Option<Duration>,
+pub struct ClientBuilder(HyperClientBuilder);
+
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        Self::new(HyperClientBuilder::new(TokioExecutor))
+    }
 }
 
 impl ClientBuilder {
-    pub(crate) fn new() -> Self {
-        ClientBuilder {
-            max_idle_per_host: usize::MAX,
-            idle_timeout: Some(Duration::from_secs(90)),
-        }
+    /// Create a builder with a configured instance of [`HyperClientBuilder`].
+    pub fn new(inner: HyperClientBuilder) -> Self {
+        Self(inner)
     }
 
     /// Sets the maximum idle connection per host allowed in the pool.
     ///
     /// Default is usize::MAX (no limit).
     pub fn pool_max_idle_per_host(&mut self, max_idle: usize) -> &mut Self {
-        self.max_idle_per_host = max_idle;
+        self.0.pool_max_idle_per_host(max_idle);
         self
     }
 
@@ -126,7 +127,22 @@ impl ClientBuilder {
     ///
     /// Default is 90 seconds.
     pub fn pool_idle_timeout(&mut self, val: Option<Duration>) -> &mut Self {
-        self.idle_timeout = val;
+        self.0.pool_idle_timeout(val);
+        self
+    }
+
+    /// Set whether the connection **must** use HTTP/2.
+    ///
+    /// The destination must either allow HTTP2 Prior Knowledge, or the
+    /// `Connect` should be configured to do use ALPN to upgrade to `h2`
+    /// as part of the connection process. This will not make the `Client`
+    /// utilize ALPN by itself.
+    ///
+    /// Note that setting this to true prevents HTTP/1 from being allowed.
+    ///
+    /// Default is false.
+    pub fn http2_only(&mut self, val: bool) -> &mut Self {
+        self.0.http2_only(val);
         self
     }
 
@@ -134,13 +150,7 @@ impl ClientBuilder {
     /// `Client`.
     pub fn build<C: NetworkConnector>(&self, connector: C) -> Client {
         Client {
-            inner: Arc::new(
-                HyperClient::builder()
-                    .pool_max_idle_per_host(self.max_idle_per_host)
-                    .pool_idle_timeout(self.idle_timeout)
-                    .executor(TokioExecutor)
-                    .build(ConnectorAdapter::new(connector)),
-            ),
+            inner: Arc::new(self.0.build(ConnectorAdapter::new(connector))),
         }
     }
 }
@@ -268,8 +278,11 @@ impl<'a> RequestBuilder<'a> {
     }
 }
 
+/// The default executor to use with the native hyper client.
+///
+/// Based on the [`tokio`] runtime.
 #[derive(Copy, Clone)]
-pub(crate) struct TokioExecutor;
+pub struct TokioExecutor;
 
 impl<F> hyper::rt::Executor<F> for TokioExecutor
 where
@@ -285,8 +298,8 @@ where
 mod tests {
     use super::*;
     use crate::connector::HttpConnector;
+    use crate::util::to_bytes;
     use headers::ContentType;
-    use hyper::body::to_bytes;
     use hyper::StatusCode;
     use std::net::SocketAddr;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -352,9 +365,6 @@ mod tests {
         let connector = HttpConnector::new().connect_timeout(Some(Duration::from_millis(100)));
         let client = Client::with_connector(connector);
         let err = client.get(url).unwrap().send().await.unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "error trying to connect: I/O error: connection timed out"
-        );
+        assert_eq!(err.to_string(), "client error (Connect)");
     }
 }

--- a/simple-hyper-client/src/blocking/body.rs
+++ b/simple-hyper-client/src/blocking/body.rs
@@ -6,10 +6,11 @@
 
 use super::client::KeepClientAlive;
 
+use futures_util::StreamExt;
+use http_body_util::BodyExt;
+use hyper::body::Body as HyperBody;
 use hyper::body::{Buf, Bytes};
-use hyper::Body as HyperBody;
 use tokio::sync::mpsc;
-use tokio_stream::StreamExt;
 
 use std::future::Future;
 use std::{fmt, io};
@@ -28,35 +29,54 @@ impl fmt::Debug for Body {
 }
 
 impl Body {
-    pub(super) fn new(
-        mut hyper_body: HyperBody,
-    ) -> (impl Future<Output = ()> + Send + 'static, Self) {
+    pub(super) fn new<T>(hyper_body: T) -> (impl Future<Output = ()> + Send + 'static, Self)
+    where
+        T: HyperBody + Send + 'static,
+        T::Data: Send + Into<Bytes>,
+        T::Error: std::error::Error + Send + Sync + 'static,
+    {
         let (tx, rx) = mpsc::channel(1);
+
         let fut = async move {
+            let mut stream = std::pin::pin!(hyper_body.into_data_stream());
+
             loop {
                 tokio::select! {
                     _ = tx.closed() => {
                         break; // body has been dropped.
                     }
-                    res = hyper_body.next() => {
+
+                    res = stream.next() => {
                         let res = match res {
                             None => break, // EOF
-                            Some(Ok(chunk)) if chunk.is_empty() => continue,
-                            Some(Ok(chunk)) => Ok(chunk),
+
+                            Some(Ok(chunk)) => {
+                                let chunk = chunk.into();
+
+                                if chunk.is_empty() {
+                                    continue;
+                                } else {
+                                    Ok(chunk)
+                                }
+                            }
+
                             Some(Err(e)) => Err(io::Error::new(io::ErrorKind::Other, e)),
                         };
-                        if let Err(_) = tx.send(res).await {
+
+                        if tx.send(res).await.is_err() {
                             break; // body has been dropped.
                         }
                     }
                 }
             }
         };
+
         let body = Body {
             keep_client_alive: KeepClientAlive::empty(),
             bytes: Bytes::new(),
             rx,
         };
+
         (fut, body)
     }
 }
@@ -79,10 +99,10 @@ impl io::Read for Body {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::Body as HyperBody;
-    use std::future::Future;
-    use std::io::{self, Read};
-    use std::thread;
+    use http_body_util::{Channel, Full, StreamBody};
+    use hyper::body::Frame;
+    use std::io::Read;
+    use std::{future::Future, thread};
     use tokio::time::{self, Duration};
 
     fn run_future<F: Future<Output = ()> + Send + 'static>(fut: F) {
@@ -97,7 +117,7 @@ mod tests {
 
     #[test]
     fn single_chunk() {
-        let body = HyperBody::from("hello, world!");
+        let body = Full::new(&b"hello, world!"[..]);
         let (fut, mut reader) = Body::new(body);
         run_future(fut);
 
@@ -108,16 +128,16 @@ mod tests {
 
     #[test]
     fn multiple_chunks() {
-        let (mut sender, body) = HyperBody::channel();
+        let (mut sender, body) = Channel::<&[u8]>::new(5);
         let (fut, mut reader) = Body::new(body);
 
         run_future(async move {
             let h = tokio::spawn(fut);
 
-            sender.send_data("hello".into()).await.unwrap();
+            sender.send_data(b"hello").await.unwrap();
             time::sleep(Duration::from_millis(10)).await;
-            sender.send_data(", ".into()).await.unwrap();
-            sender.send_data("world!".into()).await.unwrap();
+            sender.send_data(b", ").await.unwrap();
+            sender.send_data(b"world!").await.unwrap();
 
             drop(sender);
             h.await.unwrap();
@@ -130,16 +150,16 @@ mod tests {
 
     #[test]
     fn with_empty_chunk() {
-        let (mut sender, body) = HyperBody::channel();
+        let (mut sender, body) = Channel::<&[u8]>::new(5);
         let (fut, mut reader) = Body::new(body);
 
         run_future(async move {
             let h = tokio::spawn(fut);
 
-            sender.send_data("hello".into()).await.unwrap();
+            sender.send_data(b"hello").await.unwrap();
             time::sleep(Duration::from_millis(10)).await;
-            sender.send_data("".into()).await.unwrap();
-            sender.send_data(", world!".into()).await.unwrap();
+            sender.send_data(b"").await.unwrap();
+            sender.send_data(b", world!").await.unwrap();
 
             drop(sender);
             h.await.unwrap();
@@ -152,14 +172,16 @@ mod tests {
 
     #[test]
     fn hyper_error() {
-        let chunks: Vec<Result<_, io::Error>> = vec![
-            Ok("hello"),
-            Ok(" "),
-            Ok("world"),
+        eprintln!("test");
+        let chunks: Vec<Result<&[u8], io::Error>> = vec![
+            Ok(b"hello"),
+            Ok(b" "),
+            Ok(b"world"),
             Err(io::ErrorKind::BrokenPipe.into()),
         ];
+        let chunks = chunks.into_iter().map(|res| res.map(Frame::data));
         let stream = futures_util::stream::iter(chunks);
-        let body = HyperBody::wrap_stream(stream);
+        let body = StreamBody::new(stream);
         let (fut, mut reader) = Body::new(body);
 
         run_future(fut);

--- a/simple-hyper-client/src/blocking/client.rs
+++ b/simple-hyper-client/src/blocking/client.rs
@@ -113,9 +113,13 @@ impl Client {
 pub struct ClientBuilder(AsyncClientBuilder);
 
 impl ClientBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Create a builder with a configured instance of [`HyperClientBuilder`].
-    pub fn new(inner: HyperClientBuilder) -> Self {
-        ClientBuilder(AsyncClientBuilder::new(inner))
+    pub fn from_hyper_client_builder(inner: HyperClientBuilder) -> Self {
+        Self(AsyncClientBuilder::from_hyper_client_builder(inner))
     }
 
     /// Sets the maximum idle connection per host allowed in the pool.
@@ -137,11 +141,6 @@ impl ClientBuilder {
     }
 
     /// Set whether the connection **must** use HTTP/2.
-    ///
-    /// The destination must either allow HTTP2 Prior Knowledge, or the
-    /// `Connect` should be configured to do use ALPN to upgrade to `h2`
-    /// as part of the connection process. This will not make the `Client`
-    /// utilize ALPN by itself.
     ///
     /// Note that setting this to true prevents HTTP/1 from being allowed.
     ///

--- a/simple-hyper-client/src/blocking/client.rs
+++ b/simple-hyper-client/src/blocking/client.rs
@@ -14,6 +14,7 @@ use crate::shared_body::SharedBody;
 use futures_executor::block_on;
 use headers::{Header, HeaderMap, HeaderMapExt};
 use hyper::{Method, Uri};
+use hyper_util::client::legacy::Builder as HyperClientBuilder;
 use tokio::runtime;
 use tokio::sync::{mpsc, oneshot};
 
@@ -31,7 +32,7 @@ use std::time::Duration;
 /// let response = client.get("http://example.com/")?.send()?;
 /// ```
 ///
-/// [hyper's `Client` type]: https://docs.rs/hyper/latest/hyper/client/struct.Client.html
+/// [hyper's `Client` type]: https://docs.rs/hyper-util/latest/hyper_util/client/legacy/struct.Client.html
 #[derive(Clone)]
 pub struct Client {
     inner: Arc<ClientInner>,
@@ -59,7 +60,7 @@ macro_rules! define_method_fn {
         #[doc = " request with the specified URI."]
         ///
         /// Returns an error if `uri` is invalid.
-        pub fn $name<U>(&self, uri: U) -> Result<RequestBuilder, Error>
+        pub fn $name<U>(&self, uri: U) -> Result<RequestBuilder<'_>, Error>
         where
             Uri: TryFrom<U>,
             <Uri as TryFrom<U>>::Error: Into<http::Error>,
@@ -75,17 +76,17 @@ macro_rules! define_method_fn {
 
 impl Client {
     pub fn builder() -> ClientBuilder {
-        ClientBuilder::new()
+        ClientBuilder::default()
     }
 
     pub fn with_connector<C: NetworkConnector>(connector: C) -> Self {
-        ClientBuilder::new().build(connector)
+        ClientBuilder::default().build(connector)
     }
 
     /// Initiate a request with the specified method and URI.
     ///
     /// Returns an error if `uri` is invalid.
-    pub fn request<U>(&self, method: Method, uri: U) -> Result<RequestBuilder, Error>
+    pub fn request<U>(&self, method: Method, uri: U) -> Result<RequestBuilder<'_>, Error>
     where
         Uri: TryFrom<U>,
         <Uri as TryFrom<U>>::Error: Into<http::Error>,
@@ -108,12 +109,13 @@ impl Client {
 /// A builder for [`Client`].
 ///
 /// [`Client`]: struct.Client.html
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct ClientBuilder(AsyncClientBuilder);
 
 impl ClientBuilder {
-    fn new() -> Self {
-        ClientBuilder(AsyncClientBuilder::new())
+    /// Create a builder with a configured instance of [`HyperClientBuilder`].
+    pub fn new(inner: HyperClientBuilder) -> Self {
+        ClientBuilder(AsyncClientBuilder::new(inner))
     }
 
     /// Sets the maximum idle connection per host allowed in the pool.
@@ -131,6 +133,21 @@ impl ClientBuilder {
     /// Default is 90 seconds.
     pub fn pool_idle_timeout(&mut self, val: Option<Duration>) -> &mut Self {
         self.0.pool_idle_timeout(val);
+        self
+    }
+
+    /// Set whether the connection **must** use HTTP/2.
+    ///
+    /// The destination must either allow HTTP2 Prior Knowledge, or the
+    /// `Connect` should be configured to do use ALPN to upgrade to `h2`
+    /// as part of the connection process. This will not make the `Client`
+    /// utilize ALPN by itself.
+    ///
+    /// Note that setting this to true prevents HTTP/1 from being allowed.
+    ///
+    /// Default is false.
+    pub fn http2_only(&mut self, val: bool) -> &mut Self {
+        self.0.http2_only(val);
         self
     }
 

--- a/simple-hyper-client/src/connector/http.rs
+++ b/simple-hyper-client/src/connector/http.rs
@@ -6,8 +6,8 @@
 
 use crate::connector::{NetworkConnection, NetworkConnector};
 use crate::connector_impl::connect;
-use hyper::client::connect::{Connected, Connection};
 use hyper::Uri;
+use hyper_util::client::legacy::connect::{Connected, Connection};
 use std::error::Error as StdError;
 use std::future::Future;
 use std::pin::Pin;

--- a/simple-hyper-client/src/connector/hyper_adapter.rs
+++ b/simple-hyper-client/src/connector/hyper_adapter.rs
@@ -6,9 +6,9 @@
 
 use crate::connector::{NetworkConnection, NetworkConnector};
 
-use hyper::client::connect::Connection;
 use hyper::service::Service;
 use hyper::Uri;
+use hyper_util::client::legacy::connect::Connection;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Mutex;
 

--- a/simple-hyper-client/src/connector/mod.rs
+++ b/simple-hyper-client/src/connector/mod.rs
@@ -72,6 +72,48 @@ impl AsyncWrite for NetworkConnection {
     }
 }
 
+impl hyper::rt::Read for NetworkConnection {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        mut buf: hyper::rt::ReadBufCursor<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        // SAFETY: Never uninitialize any bytes that may have been initialized before.
+        let mut tmp_buf = unsafe { ReadBuf::uninit(buf.as_mut()) };
+
+        let bytes_read = match AsyncRead::poll_read(self, cx, &mut tmp_buf) {
+            Poll::Ready(Ok(())) => tmp_buf.filled().len(),
+            other => return other,
+        };
+
+        // SAFETY: Advance by exactly the number of bytes we've just initialized.
+        unsafe { buf.advance(bytes_read) };
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl hyper::rt::Write for NetworkConnection {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        AsyncWrite::poll_write(self, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        AsyncWrite::poll_flush(self, cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        AsyncWrite::poll_shutdown(self, cx)
+    }
+}
+
 /// Network connector trait with type erasure
 pub trait NetworkConnector: Send + Sync + 'static {
     fn connect(
@@ -112,46 +154,5 @@ impl tower_service::Service<Uri> for ConnectorAdapter {
 
     fn call(&mut self, uri: Uri) -> Self::Future {
         self.0.connect(uri)
-    }
-}
-
-impl hyper::rt::Read for NetworkConnection {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        mut buf: hyper::rt::ReadBufCursor<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        // TODO: Avoid unsafe.
-        let mut tmp_buf = unsafe { ReadBuf::uninit(buf.as_mut()) };
-
-        let bytes_read = match AsyncRead::poll_read(self, cx, &mut tmp_buf) {
-            Poll::Ready(Ok(())) => tmp_buf.filled().len(),
-            other => return other,
-        };
-
-        unsafe { buf.advance(bytes_read) };
-
-        Poll::Ready(Ok(()))
-    }
-}
-
-impl hyper::rt::Write for NetworkConnection {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, std::io::Error>> {
-        AsyncWrite::poll_write(self, cx, buf)
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
-        AsyncWrite::poll_flush(self, cx)
-    }
-
-    fn poll_shutdown(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        AsyncWrite::poll_shutdown(self, cx)
     }
 }

--- a/simple-hyper-client/src/connector/mod.rs
+++ b/simple-hyper-client/src/connector/mod.rs
@@ -4,9 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use hyper::client::connect::{Connected, Connection};
 use hyper::service::Service;
 use hyper::Uri;
+use hyper_util::client::legacy::connect::{Connected, Connection};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use std::error::Error as StdError;
@@ -96,11 +96,62 @@ impl Service<Uri> for ConnectorAdapter {
     type Error = Box<dyn StdError + Send + Sync>;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
+    fn call(&self, uri: Uri) -> Self::Future {
+        self.0.connect(uri)
+    }
+}
+
+impl tower_service::Service<Uri> for ConnectorAdapter {
+    type Response = NetworkConnection;
+    type Error = Box<dyn StdError + Send + Sync>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, uri: Uri) -> Self::Future {
         self.0.connect(uri)
+    }
+}
+
+impl hyper::rt::Read for NetworkConnection {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        mut buf: hyper::rt::ReadBufCursor<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        // TODO: Avoid unsafe.
+        let mut tmp_buf = unsafe { ReadBuf::uninit(buf.as_mut()) };
+
+        let bytes_read = match AsyncRead::poll_read(self, cx, &mut tmp_buf) {
+            Poll::Ready(Ok(())) => tmp_buf.filled().len(),
+            other => return other,
+        };
+
+        unsafe { buf.advance(bytes_read) };
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl hyper::rt::Write for NetworkConnection {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        AsyncWrite::poll_write(self, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        AsyncWrite::poll_flush(self, cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        AsyncWrite::poll_shutdown(self, cx)
     }
 }

--- a/simple-hyper-client/src/error.rs
+++ b/simple-hyper-client/src/error.rs
@@ -6,45 +6,16 @@
 
 use hyper::Method;
 
-use std::{error, fmt};
+pub type HyperClientError = hyper_util::client::legacy::Error;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    Http(http::Error),
-    Hyper(hyper::Error),
+    #[error(transparent)]
+    Http(#[from] http::Error),
+
+    #[error(transparent)]
+    Client(#[from] HyperClientError),
+
+    #[error("{0} requests are not allowed to have a body")]
     BodyNotAllowed(Method),
-}
-
-impl From<http::Error> for Error {
-    fn from(e: http::Error) -> Self {
-        Error::Http(e)
-    }
-}
-
-impl From<hyper::Error> for Error {
-    fn from(e: hyper::Error) -> Self {
-        Error::Hyper(e)
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Error::Http(ref e) => write!(f, "{}", e),
-            Error::Hyper(ref e) => write!(f, "{}", e),
-            Error::BodyNotAllowed(ref m) => {
-                write!(f, "{} requests are not allowed to have a body", m)
-            }
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match *self {
-            Error::Http(ref e) => Some(e),
-            Error::Hyper(ref e) => Some(e),
-            Error::BodyNotAllowed(_) => None,
-        }
-    }
 }

--- a/simple-hyper-client/src/lib.rs
+++ b/simple-hyper-client/src/lib.rs
@@ -9,20 +9,28 @@ pub mod blocking;
 mod connector;
 mod error;
 mod shared_body;
+mod util;
 
 pub use self::async_client::*;
 pub use self::connector::{
     ConnectError, HttpConnection, HttpConnector, HyperConnectorAdapter, NetworkConnection,
     NetworkConnector,
 };
-pub use self::error::Error;
+pub use self::error::{Error, HyperClientError};
 pub use self::shared_body::SharedBody;
+pub use self::util::{aggregate, to_bytes};
 
-pub use hyper::body::{aggregate, to_bytes, Buf, Bytes, HttpBody};
+pub use hyper::body::{Body, Buf, Bytes, Incoming};
 pub use hyper::{self, Method, StatusCode, Uri, Version};
+pub use hyper_util::client::legacy::{Builder as HyperClientBuilder, Client as HyperClient};
+pub use tower_service;
 
 pub type Request = hyper::Request<SharedBody>;
-pub type Response = hyper::Response<hyper::Body>;
+pub type Response = hyper::Response<Incoming>;
+
+pub mod compat {
+    pub use hyper_util::client::legacy::connect::{Connected, Connection};
+}
 
 #[doc(hidden)]
 pub mod connector_impl;

--- a/simple-hyper-client/src/shared_body.rs
+++ b/simple-hyper-client/src/shared_body.rs
@@ -4,13 +4,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use headers::HeaderMap;
-use hyper::body::{Buf, HttpBody};
+use hyper::body::{Body, Buf, Frame};
 
+use std::cmp;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use std::{cmp, io};
 
 /// This is an alternative to `hyper::Body` for use with HTTP `Request`s
 ///
@@ -85,28 +84,23 @@ impl From<&'static str> for SharedBody {
     }
 }
 
-impl HttpBody for SharedBody {
+impl Body for SharedBody {
     type Data = SharedBuf;
-    type Error = io::Error;
+    type Error = crate::Error;
 
-    fn poll_data(
+    fn poll_frame(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         let opt = self
             .get_mut()
             .0
             .take()
             .map(|bytes| SharedBuf { bytes, pos: 0 })
+            .map(Frame::data)
             .map(Ok);
-        Poll::Ready(opt)
-    }
 
-    fn poll_trailers(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
-        Poll::Ready(Ok(None))
+        Poll::Ready(opt)
     }
 }
 

--- a/simple-hyper-client/src/util.rs
+++ b/simple-hyper-client/src/util.rs
@@ -1,0 +1,21 @@
+use http_body_util::BodyExt;
+use hyper::body::{Body, Buf, Bytes};
+
+/// Collects all of the data frames from this body into a [`Buf`].
+///
+/// This function avoids copying the data and is useful when you don't need
+/// a contiguous slice of data.
+pub async fn aggregate<T>(body: T) -> Result<impl Buf, T::Error>
+where
+    T: Body,
+{
+    Ok(body.collect().await?.aggregate())
+}
+
+/// Collects all of the data frames from this body into [`Bytes`].
+pub async fn to_bytes<T>(body: T) -> Result<Bytes, T::Error>
+where
+    T: Body,
+{
+    Ok(body.collect().await?.to_bytes())
+}

--- a/simple-hyper-client/src/util.rs
+++ b/simple-hyper-client/src/util.rs
@@ -1,10 +1,16 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use http_body_util::BodyExt;
 use hyper::body::{Body, Buf, Bytes};
 
 /// Collects all of the data frames from this body into a [`Buf`].
 ///
-/// This function avoids copying the data and is useful when you don't need
-/// a contiguous slice of data.
+/// As opposed to [`to_bytes()`], this function avoids copying the data
+/// and is useful when you don't need a contiguous slice of data.
 pub async fn aggregate<T>(body: T) -> Result<impl Buf, T::Error>
 where
     T: Body,


### PR DESCRIPTION
Upgrades the `hyper` dependency to v1.

Other changes:
- Added a method on the `ClientBuilder` to enforce HTTP/2. Alternatively, `ClientBuilder` can be created with a preconfigured instance of `HyperClientBuilder`.
- Relaxed dependency version requirements for easier integration into the consumer code.