### PR TITLE
Reintroduce `SharedBody` type and ensure that wrapped bodies have an accurate size hint

### DIFF
--- a/simple-hyper-client/src/async_client.rs
+++ b/simple-hyper-client/src/async_client.rs
@@ -293,13 +293,16 @@ mod tests {
     use super::*;
     use crate::connector::HttpConnector;
     use crate::util::to_bytes;
+
     use headers::{ContentLength, ContentType};
+    use hyper::body::Bytes;
     use hyper::StatusCode;
-    use std::net::SocketAddr;
     use test_case::test_case;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::sync::oneshot;
+
+    use std::net::SocketAddr;
 
     const RESPONSE_OK: &str = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, world!\r\n";
     const RESPONSE_404: &str =
@@ -409,5 +412,28 @@ mod tests {
         let client = Client::with_connector(connector);
         let err = client.get(url).unwrap().send().await.unwrap_err();
         assert_eq!(err.to_string(), "client error (Connect)");
+    }
+
+    #[test]
+    fn wrapped_body_size_hint() {
+        let body = http_body_util::Full::new(Bytes::from_static(r#"{"key":"value"}"#.as_bytes()));
+        let unwrapped_size_hint = body.size_hint();
+
+        let request = Client::with_connector(HttpConnector::new())
+            .post("https://localhost/")
+            .unwrap()
+            .header(ContentType::json())
+            .body(RequestBody::wrap(body))
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.body().size_hint().lower(),
+            unwrapped_size_hint.lower()
+        );
+        assert_eq!(
+            request.body().size_hint().upper(),
+            unwrapped_size_hint.upper()
+        );
     }
 }

--- a/simple-hyper-client/src/body/mod.rs
+++ b/simple-hyper-client/src/body/mod.rs
@@ -4,15 +4,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use self::shared::{SharedBody, SharedBuf};
+
 use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt;
 use hyper::body::{Body, Buf, Frame, SizeHint};
 
-use std::cmp;
 use std::error::Error;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
+
+pub(crate) mod shared;
 
 /// This is an implementation of `hyper::body::Body` for use with HTTP
 /// `Request`s.
@@ -23,14 +25,14 @@ use std::task::{Context, Poll};
 pub struct RequestBody(InnerBody);
 
 enum InnerBody {
-    Shared(Option<SharedBytes>),
+    Shared(SharedBody),
     Wrapped(BoxBody<Box<dyn Buf + Send + Sync>, Box<dyn Error + Send + Sync>>),
 }
 
 impl RequestBody {
     /// Create an empty request body.
     pub fn empty() -> Self {
-        Self(InnerBody::Shared(None))
+        SharedBody::empty().into()
     }
 
     /// Create a `RequestBody` from an arbitrary other `hyper::body::Body`.
@@ -56,35 +58,9 @@ impl Default for RequestBody {
     }
 }
 
-impl From<Arc<Vec<u8>>> for RequestBody {
-    fn from(arc: Arc<Vec<u8>>) -> Self {
-        Self(InnerBody::Shared(Some(SharedBytes::Arc(arc))))
-    }
-}
-
-impl From<Vec<u8>> for RequestBody {
-    fn from(vec: Vec<u8>) -> Self {
-        Self(InnerBody::Shared(Some(SharedBytes::Arc(Arc::new(vec)))))
-    }
-}
-
-impl From<String> for RequestBody {
-    fn from(s: String) -> Self {
-        Self(InnerBody::Shared(Some(SharedBytes::Arc(Arc::new(
-            s.into_bytes(),
-        )))))
-    }
-}
-
-impl From<&'static [u8]> for RequestBody {
-    fn from(slice: &'static [u8]) -> Self {
-        Self(InnerBody::Shared(Some(SharedBytes::Static(slice))))
-    }
-}
-
-impl From<&'static str> for RequestBody {
-    fn from(s: &'static str) -> Self {
-        Self(InnerBody::Shared(Some(SharedBytes::Static(s.as_bytes()))))
+impl<T: Into<SharedBody>> From<T> for RequestBody {
+    fn from(shared_body: T) -> Self {
+        Self(InnerBody::Shared(shared_body.into()))
     }
 }
 
@@ -97,14 +73,13 @@ impl Body for RequestBody {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         match &mut self.get_mut().0 {
-            InnerBody::Shared(maybe_bytes) => {
-                let opt = maybe_bytes
-                    .take()
-                    .map(|bytes| Buffer::Shared(SharedBuf { bytes, pos: 0 }))
-                    .map(Frame::data)
-                    .map(Ok);
-                Poll::Ready(opt)
-            }
+            InnerBody::Shared(shared_body) => SharedBody::poll_frame(Pin::new(shared_body), cx)
+                .map(|opt| {
+                    opt.map(|res| {
+                        res.map(|frame| frame.map_data(|bytes| Buffer::Shared(bytes)))
+                            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+                    })
+                }),
 
             InnerBody::Wrapped(box_body) => {
                 BoxBody::poll_frame(Pin::new(box_body), cx).map(|opt| {
@@ -116,20 +91,14 @@ impl Body for RequestBody {
 
     fn is_end_stream(&self) -> bool {
         match &self.0 {
-            InnerBody::Shared(maybe_bytes) => maybe_bytes.is_none(),
+            InnerBody::Shared(shared_body) => shared_body.is_end_stream(),
             InnerBody::Wrapped(box_body) => box_body.is_end_stream(),
         }
     }
 
     fn size_hint(&self) -> SizeHint {
         match &self.0 {
-            InnerBody::Shared(maybe_bytes) => {
-                let len = maybe_bytes
-                    .as_ref()
-                    .map(SharedBytes::len)
-                    .unwrap_or_default();
-                SizeHint::with_exact(len as u64)
-            }
+            InnerBody::Shared(shared_body) => shared_body.size_hint(),
             InnerBody::Wrapped(box_body) => box_body.size_hint(),
         }
     }
@@ -160,48 +129,6 @@ impl Buf for Buffer {
         match self {
             Self::Shared(shared_buf) => shared_buf.advance(cnt),
             Self::Wrapped(bytes) => bytes.advance(cnt),
-        }
-    }
-}
-
-pub struct SharedBuf {
-    bytes: SharedBytes,
-    pos: usize,
-}
-
-impl SharedBuf {
-    fn len(&self) -> usize {
-        self.bytes.len()
-    }
-}
-
-impl Buf for SharedBuf {
-    fn remaining(&self) -> usize {
-        self.len() - self.pos
-    }
-
-    fn chunk(&self) -> &[u8] {
-        match self.bytes {
-            SharedBytes::Arc(ref bytes) => &bytes[self.pos..],
-            SharedBytes::Static(ref bytes) => &bytes[self.pos..],
-        }
-    }
-
-    fn advance(&mut self, cnt: usize) {
-        self.pos = cmp::min(self.len(), self.pos + cnt);
-    }
-}
-
-enum SharedBytes {
-    Arc(Arc<Vec<u8>>),
-    Static(&'static [u8]),
-}
-
-impl SharedBytes {
-    fn len(&self) -> usize {
-        match self {
-            Self::Arc(ref bytes) => bytes.len(),
-            Self::Static(ref bytes) => bytes.len(),
         }
     }
 }

--- a/simple-hyper-client/src/body/mod.rs
+++ b/simple-hyper-client/src/body/mod.rs
@@ -8,7 +8,7 @@ use self::shared::{SharedBody, SharedBuf};
 
 use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt;
-use hyper::body::{Body, Buf, Frame, SizeHint};
+use hyper::body::{Body, Buf, Bytes, Frame, SizeHint};
 
 use std::error::Error;
 use std::pin::Pin;
@@ -21,12 +21,12 @@ pub(crate) mod shared;
 ///
 /// This can be constructed from `Arc<Vec<u8>>`, allowing the data to be
 /// shared. The type can also wrap arbitrary other `hyper::body::Body`
-/// instances.
+/// instances, as long as they have `Bytes` as their `Data` associated type.
 pub struct RequestBody(InnerBody);
 
 enum InnerBody {
     Shared(SharedBody),
-    Wrapped(BoxBody<Box<dyn Buf + Send + Sync>, Box<dyn Error + Send + Sync>>),
+    Wrapped(BoxBody<Bytes, Box<dyn Error + Send + Sync>>),
 }
 
 impl RequestBody {
@@ -36,15 +36,18 @@ impl RequestBody {
     }
 
     /// Create a `RequestBody` from an arbitrary other `hyper::body::Body`.
-    pub fn wrap<B, D, E>(body: B) -> Self
+    pub fn wrap<B, E>(body: B) -> Self
     where
-        B: Body<Data = D, Error = E> + Send + Sync + 'static,
-        D: Buf + Send + Sync + 'static,
+        B: Body<Data = Bytes, Error = E> + Send + Sync + 'static,
         E: Error + Send + Sync + 'static,
     {
+        // Note: we do not support wrapping bodies with arbitrary `Buf`s as their
+        // `Data` associated type, because that would require us to call
+        // `BodyExt::map_frame()`, which returns a body type that does not provide
+        // accurate size hints, which can affect the transfer-encoding and
+        // content-length headers sent along with the request.
         Self(InnerBody::Wrapped(
-            body.map_frame(|f| f.map_data(|d| Box::new(d) as Box<dyn Buf + Send + Sync>))
-                .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+            body.map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
                 .boxed(),
         ))
     }
@@ -107,7 +110,7 @@ impl Body for RequestBody {
 /// The `hyper::body::Body::Data` type for a [`RequestBody`].
 pub enum Buffer {
     Shared(SharedBuf),
-    Wrapped(Box<dyn Buf + Send + Sync>),
+    Wrapped(Bytes),
 }
 
 impl Buf for Buffer {

--- a/simple-hyper-client/src/body/shared.rs
+++ b/simple-hyper-client/src/body/shared.rs
@@ -1,0 +1,151 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use hyper::body::{Body, Buf, Frame, SizeHint};
+
+use std::cmp;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+/// This is an implementation of `hyper::body::Body` for use with HTTP
+/// `Request`s.
+///
+/// This can be constructed from `Arc<Vec<u8>>`, allowing the data to be
+/// shared. It also implements `Clone` and `AsRef<[u8]>`, and it provides a
+/// method to get its length and implements.
+#[derive(Clone, Default)]
+pub struct SharedBody(Option<SharedBytes>);
+
+impl SharedBody {
+    /// Create an empty request body.
+    #[inline]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Returns the length of the body in bytes.
+    pub fn len(&self) -> usize {
+        self.0.as_ref().map(SharedBytes::len).unwrap_or_default()
+    }
+}
+
+impl From<Arc<Vec<u8>>> for SharedBody {
+    fn from(arc: Arc<Vec<u8>>) -> Self {
+        Self(Some(SharedBytes::Arc(arc)))
+    }
+}
+
+impl From<Vec<u8>> for SharedBody {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(Some(SharedBytes::Arc(Arc::new(vec))))
+    }
+}
+
+impl From<String> for SharedBody {
+    fn from(s: String) -> Self {
+        Self(Some(SharedBytes::Arc(Arc::new(s.into_bytes()))))
+    }
+}
+
+impl From<&'static [u8]> for SharedBody {
+    fn from(slice: &'static [u8]) -> Self {
+        Self(Some(SharedBytes::Static(slice)))
+    }
+}
+
+impl From<&'static str> for SharedBody {
+    fn from(s: &'static str) -> Self {
+        Self(Some(SharedBytes::Static(s.as_bytes())))
+    }
+}
+
+impl AsRef<[u8]> for SharedBody {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref().map(SharedBytes::as_ref).unwrap_or(&[])
+    }
+}
+
+impl Body for SharedBody {
+    type Data = SharedBuf;
+    type Error = io::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let opt = self
+            .get_mut()
+            .0
+            .take()
+            .map(|bytes| SharedBuf { bytes, pos: 0 })
+            .map(Frame::data)
+            .map(Ok);
+        Poll::Ready(opt)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.0.is_none()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        let len = self.0.as_ref().map(SharedBytes::len).unwrap_or_default();
+        SizeHint::with_exact(len as u64)
+    }
+}
+
+pub struct SharedBuf {
+    bytes: SharedBytes,
+    pos: usize,
+}
+
+impl SharedBuf {
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+}
+
+impl Buf for SharedBuf {
+    fn remaining(&self) -> usize {
+        self.len() - self.pos
+    }
+
+    fn chunk(&self) -> &[u8] {
+        match self.bytes {
+            SharedBytes::Arc(ref bytes) => &bytes[self.pos..],
+            SharedBytes::Static(ref bytes) => &bytes[self.pos..],
+        }
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        self.pos = cmp::min(self.len(), self.pos + cnt);
+    }
+}
+
+#[derive(Clone)]
+enum SharedBytes {
+    Arc(Arc<Vec<u8>>),
+    Static(&'static [u8]),
+}
+
+impl SharedBytes {
+    fn len(&self) -> usize {
+        match self {
+            Self::Arc(ref bytes) => bytes.len(),
+            Self::Static(ref bytes) => bytes.len(),
+        }
+    }
+}
+
+impl AsRef<[u8]> for SharedBytes {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Arc(vec) => vec,
+            Self::Static(slice) => slice,
+        }
+    }
+}

--- a/simple-hyper-client/src/lib.rs
+++ b/simple-hyper-client/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 mod util;
 
 pub use self::async_client::*;
-pub use self::body::RequestBody;
+pub use self::body::{shared::SharedBody, RequestBody};
 pub use self::connector::{
     ConnectError, HttpConnection, HttpConnector, HyperConnectorAdapter, NetworkConnection,
     NetworkConnector,


### PR DESCRIPTION
This PR has two changes:
* It re-introduces the `SharedBody`, which can be more convenient to work with than `RequestBody` in certain circumstances because it exposes a `len()` method and it implements `AsRef<[u8]>` and `Clone`.
* Fixes an issue where wrapped bodies would not have an accurate size hint. Unfortunately this fix does limit the kinds of bodies we can wrap. Specifically, we now only support wrapping bodies with `Bytes` as their `Data` associated type.
