### PR TITLE
Improve error messages

### DIFF
--- a/simple-hyper-client/src/async_client.rs
+++ b/simple-hyper-client/src/async_client.rs
@@ -411,7 +411,7 @@ mod tests {
         let connector = HttpConnector::new().connect_timeout(Some(Duration::from_millis(100)));
         let client = Client::with_connector(connector);
         let err = client.get(url).unwrap().send().await.unwrap_err();
-        assert_eq!(err.to_string(), "client error (Connect)");
+        assert_eq!(err.to_string(), "client error (Connect): ConnectError(\"I/O error\", Custom { kind: TimedOut, error: \"connection timed out\" })");
     }
 
     #[test]

--- a/simple-hyper-client/src/async_client.rs
+++ b/simple-hyper-client/src/async_client.rs
@@ -411,7 +411,10 @@ mod tests {
         let connector = HttpConnector::new().connect_timeout(Some(Duration::from_millis(100)));
         let client = Client::with_connector(connector);
         let err = client.get(url).unwrap().send().await.unwrap_err();
-        assert_eq!(err.to_string(), "client error (Connect): ConnectError(\"I/O error\", Custom { kind: TimedOut, error: \"connection timed out\" })");
+        assert_eq!(
+            err.to_string(),
+            "client error (Connect): I/O error: connection timed out"
+        );
     }
 
     #[test]

--- a/simple-hyper-client/src/error.rs
+++ b/simple-hyper-client/src/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
 
 fn render_source_error(err: &HyperClientError) -> String {
     if let Some(err) = error::Error::source(err) {
-        format!(": {err:?}")
+        format!(": {err}")
     } else {
         Default::default()
     }

--- a/simple-hyper-client/src/error.rs
+++ b/simple-hyper-client/src/error.rs
@@ -6,6 +6,7 @@
 
 use derive_more::{IsVariant, TryUnwrap, Unwrap};
 use hyper::Method;
+use std::error;
 
 pub type HyperClientError = hyper_util::client::legacy::Error;
 
@@ -16,9 +17,17 @@ pub enum Error {
     #[error(transparent)]
     Http(#[from] http::Error),
 
-    #[error(transparent)]
+    #[error("{0}{source}", source = render_source_error(.0))]
     Client(#[from] HyperClientError),
 
     #[error("{0} requests are not allowed to have a body")]
     BodyNotAllowed(Method),
+}
+
+fn render_source_error(err: &HyperClientError) -> String {
+    if let Some(err) = error::Error::source(err) {
+        format!(": {err:?}")
+    } else {
+        Default::default()
+    }
 }


### PR DESCRIPTION
This improves error messages from the legacy client by adding debug-rendered source error details.

Example:
- before: `client error (Connect)`
- after: `client error (Connect): I/O error: connection timed out`
