### PR TITLE
fix: stricter stream trait bounds

### DIFF
--- a/simple-hyper-client/src/connector/http.rs
+++ b/simple-hyper-client/src/connector/http.rs
@@ -42,6 +42,17 @@ impl HttpConnector {
         self.connect_timeout = timeout;
         self
     }
+
+    /// Connects to an endpoint and returns a [`TcpStream`] for the connection.
+    pub async fn connect_raw(
+        &self,
+        uri: Uri,
+    ) -> Result<TcpStream, Box<dyn StdError + Send + Sync>> {
+        connect(uri, false, self.connect_timeout)
+            .await
+            .map(|conn| conn.into_tcp_stream())
+            .map_err(|err| Box::new(err) as _)
+    }
 }
 
 impl NetworkConnector for HttpConnector {

--- a/simple-hyper-client/src/connector/hyper_adapter.rs
+++ b/simple-hyper-client/src/connector/hyper_adapter.rs
@@ -36,7 +36,7 @@ where
     S: Service<Uri, Response = T> + Send + 'static,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     S::Future: Unpin + Send,
-    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + Sync + 'static,
 {
     fn connect(
         &self,

--- a/simple-hyper-client/src/connector/mod.rs
+++ b/simple-hyper-client/src/connector/mod.rs
@@ -22,9 +22,12 @@ pub mod hyper_adapter;
 pub use self::http::{ConnectError, HttpConnection, HttpConnector};
 pub use self::hyper_adapter::HyperConnectorAdapter;
 
-trait NetworkStream: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static {}
+trait NetworkStream: AsyncRead + AsyncWrite + Connection + Unpin + Send + Sync + 'static {}
 
-impl<T> NetworkStream for T where T: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static {}
+impl<T> NetworkStream for T where
+    T: AsyncRead + AsyncWrite + Connection + Unpin + Send + Sync + 'static
+{
+}
 
 /// A boxed network connection
 pub struct NetworkConnection(Box<dyn NetworkStream>);
@@ -32,7 +35,7 @@ pub struct NetworkConnection(Box<dyn NetworkStream>);
 impl NetworkConnection {
     pub fn new<S>(stream: S) -> Self
     where
-        S: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+        S: AsyncRead + AsyncWrite + Connection + Unpin + Send + Sync + 'static,
     {
         NetworkConnection(Box::new(stream))
     }


### PR DESCRIPTION
- Makes  the `NetworkStream` trait bounds stricter by also requiring it to be `Sync`. This is needed for better integration with the internal consumers of the crate.
- Adds a convenience method to `HttpConnector` to connect and return a raw `TcpStream` for cases when we don't want to have the stream wrapped in `NetworkConnection`, but reuse the same machinery to establish the connection.