### PR TITLE
Use tokio timers by default

### DIFF
--- a/simple-hyper-client/src/async_client.rs
+++ b/simple-hyper-client/src/async_client.rs
@@ -12,6 +12,7 @@ use crate::{HyperClient, HyperClientBuilder, Response};
 use headers::{Header, HeaderMap, HeaderMapExt};
 use hyper::body::Body;
 use hyper::{Method, Request, Uri};
+use hyper_util::rt::TokioTimer;
 
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -110,7 +111,13 @@ impl Default for ClientBuilder {
 
 impl ClientBuilder {
     pub fn new() -> Self {
-        Self::from_hyper_client_builder(HyperClientBuilder::new(TokioExecutor))
+        let mut native_client = HyperClientBuilder::new(TokioExecutor);
+
+        native_client
+            .timer(TokioTimer::new())
+            .pool_timer(TokioTimer::new());
+
+        Self::from_hyper_client_builder(native_client)
     }
 
     /// Create a builder with a configured instance of [`HyperClientBuilder`].

--- a/simple-hyper-client/src/lib.rs
+++ b/simple-hyper-client/src/lib.rs
@@ -11,7 +11,7 @@ mod connector;
 mod error;
 mod util;
 
-pub use self::async_client::*;
+pub use self::async_client::{Client, ClientBuilder, RequestBuilder, TokioExecutor};
 pub use self::body::{shared::SharedBody, RequestBody};
 pub use self::connector::{
     ConnectError, HttpConnection, HttpConnector, HyperConnectorAdapter, NetworkConnection,
@@ -19,6 +19,7 @@ pub use self::connector::{
 };
 pub use self::error::{Error, HyperClientError};
 pub use self::util::{aggregate, to_bytes};
+pub use hyper_util::rt::TokioTimer;
 
 pub use hyper::body::{Body, Buf, Bytes, Incoming};
 pub use hyper::{self, Method, StatusCode, Uri, Version};


### PR DESCRIPTION
Initialize timers by default to `TokioTimer`. Something we forgot to do during the `hyper` upgrade.