### PR TITLE
Bugfix: ensure `content-length` request header is sent for `SharedBody::empty()`

### DIFF
--- a/simple-hyper-client/src/async_client.rs
+++ b/simple-hyper-client/src/async_client.rs
@@ -300,6 +300,7 @@ mod tests {
     use super::*;
     use crate::connector::HttpConnector;
     use crate::util::to_bytes;
+    use crate::SharedBody;
 
     use headers::{ContentLength, ContentType};
     use hyper::body::Bytes;
@@ -328,11 +329,16 @@ mod tests {
         addr
     }
 
+    #[test_case(r#"{"key":"value"}"#; "with body")]
+    #[test_case(SharedBody::empty(); "without body")]
     #[tokio::test]
-    async fn http_client() {
+    async fn http_client<B: Into<SharedBody>>(req_body: B) {
         let (tx, rx) = oneshot::channel();
         let addr = test_http_server(RESPONSE_OK, tx).await;
         let url = format!("http://{}/", addr);
+
+        let req_body = req_body.into();
+        let expected_content_length = req_body.size_hint().exact();
 
         let connector = HttpConnector::new();
         let client = Client::with_connector(connector);
@@ -340,7 +346,7 @@ mod tests {
             .post(url)
             .unwrap()
             .header(ContentType::json())
-            .body(r#"{"key":"value"}"#)
+            .body(req_body.clone())
             .send()
             .await
             .unwrap();
@@ -356,13 +362,16 @@ mod tests {
         let content_length = request
             .headers
             .iter()
-            .find(|header| header.name == ContentLength::name())
-            .unwrap();
-        assert_eq!(content_length.value, "15".as_bytes());
-        assert_eq!(
-            str::from_utf8(&req_buf[body_idx..]).unwrap(),
-            "{\"key\":\"value\"}"
-        );
+            .find(|header| header.name == ContentLength::name());
+        if let Some(expected_content_length) = expected_content_length {
+            assert_eq!(
+                content_length.unwrap().value,
+                expected_content_length.to_string().as_bytes()
+            );
+        } else {
+            assert_eq!(content_length, None);
+        }
+        assert_eq!(&req_buf[body_idx..], req_body.as_ref());
 
         assert_eq!(response.status(), StatusCode::OK);
         let response_body = to_bytes(response).await.unwrap();

--- a/simple-hyper-client/src/body/shared.rs
+++ b/simple-hyper-client/src/body/shared.rs
@@ -18,7 +18,7 @@ use std::task::{Context, Poll};
 /// This can be constructed from `Arc<Vec<u8>>`, allowing the data to be
 /// shared. It also implements `Clone` and `AsRef<[u8]>`, and it provides a
 /// method to get its length and implements.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct SharedBody(Option<SharedBytes>);
 
 impl SharedBody {
@@ -31,6 +31,15 @@ impl SharedBody {
     /// Returns the length of the body in bytes.
     pub fn len(&self) -> usize {
         self.0.as_ref().map(SharedBytes::len).unwrap_or_default()
+    }
+}
+
+impl Default for SharedBody {
+    fn default() -> Self {
+        // Note: this is different from `Self(None)` because `Self(None)` would immediately
+        // return `false` for `is_end_stream()` while `Self(Some(SharedBytes::Static(&[])))`
+        // returns `true` for `is_end_stream()` until the first call to `poll_frame()`.
+        Self(Some(SharedBytes::Static(&[])))
     }
 }
 


### PR DESCRIPTION
The `Default` implementation of `SharedBody` was incorrect. It was setting its inner field to `None`, causing `is_end_stream()` to return `false` from the start, preventing `hyper` from sending the `content-length` header for these request bodies. With this corrected implementation, `is_end_stream()` returns `true` until the first call to `poll_frame()`.