### PR TITLE
fix: export `NetworkStream` trait

### DIFF
--- a/simple-hyper-client/src/connector/mod.rs
+++ b/simple-hyper-client/src/connector/mod.rs
@@ -22,7 +22,10 @@ pub mod hyper_adapter;
 pub use self::http::{ConnectError, HttpConnection, HttpConnector};
 pub use self::hyper_adapter::HyperConnectorAdapter;
 
-trait NetworkStream: AsyncRead + AsyncWrite + Connection + Unpin + Send + Sync + 'static {}
+pub trait NetworkStream:
+    AsyncRead + AsyncWrite + Connection + Unpin + Send + Sync + 'static
+{
+}
 
 impl<T> NetworkStream for T where
     T: AsyncRead + AsyncWrite + Connection + Unpin + Send + Sync + 'static

--- a/simple-hyper-client/src/lib.rs
+++ b/simple-hyper-client/src/lib.rs
@@ -15,7 +15,7 @@ pub use self::async_client::{Client, ClientBuilder, RequestBuilder, TokioExecuto
 pub use self::body::{shared::SharedBody, RequestBody};
 pub use self::connector::{
     ConnectError, HttpConnection, HttpConnector, HyperConnectorAdapter, NetworkConnection,
-    NetworkConnector,
+    NetworkConnector, NetworkStream,
 };
 pub use self::error::{Error, HyperClientError};
 pub use self::util::{aggregate, to_bytes};


### PR DESCRIPTION
Export `NetworkStream` trait so that it's easier to specify the needed trait bounds on the consumer side.